### PR TITLE
Etl object to support 'finish' event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-etl-framework",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publisher": "Defra",
   "main": "dist/cjs/index.js",
   "private": false,

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,6 +1,6 @@
+// @ts-nocheck
 const EventEmitter = require('node:events')
 const util = require('node:util')
-// @ts-nocheck
 const { RowMetaData } = require("./rowMetaData")
 const { compose } = require("node:stream")
 
@@ -39,6 +39,7 @@ function Etl(){
                     ...self.transformationList,
                     ...self.destinationList
                 )
+                // @ts-ignore
             ).on('finish', (data) => self.emit('finish', data))
             return self
     }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,3 +1,5 @@
+const EventEmitter = require('node:events')
+const util = require('node:util')
 // @ts-nocheck
 const { RowMetaData } = require("./rowMetaData")
 const { compose } = require("node:stream")
@@ -16,6 +18,7 @@ const { compose } = require("node:stream")
  * @returns Etl
  */
 function Etl(){
+    EventEmitter.call(this)
     let self = this
     self.validatorList = []
     self.transformationList = []
@@ -36,7 +39,8 @@ function Etl(){
                     ...self.transformationList,
                     ...self.destinationList
                 )
-            )
+            ).on('finish', (data) => self.emit('finish', data))
+            return self
     }
 
     this.validator = (validator) => {
@@ -56,6 +60,8 @@ function Etl(){
 
     return
 }
+
+util.inherits(Etl, EventEmitter)
 
 module.exports = {
     Etl

--- a/test/destinations/postgresDestination.test.js
+++ b/test/destinations/postgresDestination.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('@jest/globals')
 const { PostgresDestination } = require('../../src/destinations')
-const { Readable, PassThrough } = require('node:stream')
+const { Readable } = require('node:stream')
 const { Sequelize } = require('sequelize')
 jest.mock('sequelize')
 

--- a/test/etl/etl.test.js
+++ b/test/etl/etl.test.js
@@ -1,0 +1,36 @@
+const { expect } = require("@jest/globals")
+const { Loaders, Destinations } = require("../../src")
+const fs = require("fs")
+const Etl = require("../../src/lib")
+
+jest.mock('fs')
+
+describe('csvFileDestination tests', () => {
+  afterEach(() => {
+      jest.resetAllMocks()
+  })
+  it('should fire finish event', (done) => {
+    const testData = [
+      "column1, column2, column3\n",
+      "1,2,3\n",
+      "4,5,6\n"
+    ]
+    
+    const testPath = "someRandomPath"
+    fs.__setMockFileContent(testPath, testData)
+    const etl = new Etl.Etl()
+
+    etl
+    .loader(Loaders.CSVLoader({path: testPath, columns: ["column1","column2","column3"]}))
+    .destination(Destinations.CSVFileDestination({ 
+        fileName: "SoilType_Output.csv", 
+        headers: true, 
+        includeErrors: false, 
+        quotationMarks: true
+    }))
+    .pump()
+    .on('finish', (data) => {
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Added finish event and event emitter to Etl object.

# Description

Added event emitter to Etl object with 'finish' event triggered by pipe finish event in pump function.

Fixes # (issue)

Not able to update ui/spinner when pipeline finishes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] it should fire finish event

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules