### PR TITLE
Added locale support for fakerTransformer and repo details to package…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-etl-framework",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "publisher": "Defra",
   "main": "dist/cjs/index.js",
   "private": false,
@@ -20,6 +20,7 @@
   ],
   "author": "Charlie Benger-Stevenson",
   "license": "OGL-UK-3.0",
+  "repository": "https://github.com/DEFRA/ffc-pay-etl-framework",
   "description": "A framework for creating ETL pipelines in node",
   "jest": {
     "setupFiles": [

--- a/src/transformers/README.md
+++ b/src/transformers/README.md
@@ -11,32 +11,45 @@ Currently supported transformers are :
 
 ### Options
 
-| option         | description                                                   |
-| -------------- | ------------------------------------------------------------- |
-| columns        | Array of column transformations                               |
+| option  | description                                                  |
+| ------- | ------------------------------------------------------------ |
+| columns | Array of column transformations                              |
+| locale  | See https://fakerjs.dev/guide/localization for valid locales |
 
 ### Usage
 
 ```js
-FakerTransformer(
-    { 
-        columns: [
-            {
-                name: "column2",
-                faker: "company.name"
-            }
-        ]
-    }
-)
+FakerTransformer({
+  columns: [
+    {
+      name: "column2",
+      faker: "company.name",
+    },
+  ],
+});
 ```
 
 faker is a string value that can be any of the currently supported [apis](https://fakerjs.dev/api/)
 
-e.g. 
+e.g.
 
 - finance.accountName
 - person.firstName
 - randomizer.next
+
+To create UK post code
+
+```js
+FakerTransformer({
+  columns: [
+    {
+      name: "column2",
+      faker: "location.zipCode",
+    },
+  ],
+  locale: "en_GB",
+});
+```
 
 ### Example
 
@@ -46,18 +59,16 @@ src/examples/csv-faker.js
 
 ### Options
 
-| option         | description                                                   |
-| -------------- | ------------------------------------------------------------- |
-| column         | source column to be transformed                               |
+| option | description                     |
+| ------ | ------------------------------- |
+| column | source column to be transformed |
 
 ### Usage
 
 ```js
-ToUpperCaseTransformer(
-    { 
-        column: "column2"
-    }
-)
+ToUpperCaseTransformer({
+  column: "column2",
+});
 ```
 
 ### Example

--- a/src/transformers/fakerTransformer.js
+++ b/src/transformers/fakerTransformer.js
@@ -1,5 +1,4 @@
 const { Transform } = require("node:stream")
-const { faker } = require("@faker-js/faker")
 
 /**
  * 
@@ -12,11 +11,19 @@ const { faker } = require("@faker-js/faker")
  *               }
  *           ]
  *       }
+ * @param {String} options.locale
  * @returns StreamReader
  */
 function FakerTransformer(options){
     let self = this
     self.columns = options.columns
+    let faker;
+    if(options.locale){
+        faker = require(`@faker-js/faker/locale/${options.locale}`).faker
+    } else {
+        faker = require('@faker-js/faker').faker
+    }
+    
     function getFaker(fakerType) {
         return fakerType.split('.').reduce((a,b) => {
             return Object.keys(a).length === 0 ? faker[b] : a[b]

--- a/test/transformers/fakerTransformer.test.js
+++ b/test/transformers/fakerTransformer.test.js
@@ -23,7 +23,38 @@ describe('fakerTransformer tests', () => {
                 objectMode: true,
                 transform(chunk,_,callback){
                     expect(chunk.errors.length).toEqual(0)
-                    expect(chunk[1]).not.toEqual("B")
+                    expect(chunk[1]).not.toEqual("b")
+                    done()
+                    callback(null, chunk)
+                }
+            })
+        )
+    })
+    it('should support locales', (done) => {
+        const uut = FakerTransformer({ 
+            columns: [
+                {
+                    name: "column2",
+                    faker: "location.zipCode"
+                }
+            ],
+            locale: 'en_GB'
+        })
+        const testData =["a", "b", "c"]
+        testData.errors = []
+        testData.rowId = 1
+        testData._columns = ["column1", "column2", "column3"]
+        const readable = Readable.from([testData])
+        readable
+            .pipe(uut)
+            .pipe(new PassThrough({
+                objectMode: true,
+                transform(chunk,_,callback){
+                    console.log(chunk)
+                    expect(chunk.errors.length).toEqual(0)
+                    expect(chunk[1]).not.toEqual("b")
+                    const regex = /^([A-Za-z]{2}[\d]{1,2}[A-Za-z]?)[\s]+([\d][A-Za-z]{2})$/
+                    expect(chunk[1].match(regex)[0]).toEqual(chunk[1])
                     done()
                     callback(null, chunk)
                 }


### PR DESCRIPTION
….json

# Description

Changed fakerTransformation to accept a new locale option

```js
FakerTransformer({
  columns: [
    {
      name: "column2",
      faker: "location.zipCode",
    },
  ],
  locale: "en_GB",
});
```

Fixes # (issue)

Only able to produce American zip codes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] it should support locales

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules