### PR TITLE
Feature/add sql task

### DIFF
--- a/src/database_connections/index.js
+++ b/src/database_connections/index.js
@@ -1,0 +1,5 @@
+const { PostgresDatabaseConnection } = require("./postgresDatabaseConnection")
+
+module.exports = {
+  PostgresDatabaseConnection
+}

--- a/src/database_connections/postgresDatabaseConnection.js
+++ b/src/database_connections/postgresDatabaseConnection.js
@@ -1,0 +1,47 @@
+const DEFAULT_PORT = 5432
+const { Sequelize } = require('sequelize')
+const debug = require('debug')('connection')
+
+/**
+ * 
+ * @param {Object} options 
+ * @param {Object} options.connectionname
+ * @param {Object} options.username
+ * @param {Object} options.password
+ * @param {Object} options.database
+ * @param {Object} options.host
+ * @param {Object} options.port
+ * @returns Connection
+ */
+async function PostgresDatabaseConnection(options){
+    const connectionname = options.connectionname
+    const username = options.username
+    const password = options.password
+    const database = options.database
+    const host = options.host
+    const port = options.port || DEFAULT_PORT
+
+    const sequelize = new Sequelize(database, username, password, {
+      host: host,
+      port: port,
+      dialect: 'postgres',
+      logging: false
+    })
+
+    try{
+      await sequelize.authenticate()
+      debug('sequelize.authenticate succeeded')
+      return {
+        name: connectionname,
+        db: sequelize
+      }
+    } catch(e){
+        debug('sequelize.authenticate failed')
+        debug(e)
+        throw e
+    }
+}
+
+module.exports = {
+  PostgresDatabaseConnection
+}

--- a/src/destinations/postgresDestination.js
+++ b/src/destinations/postgresDestination.js
@@ -47,11 +47,7 @@ function writeInsertStatement(columnMapping, table, chunk){
  * 
  * @param {Object} options 
  * @param {Object} options.table
- * @param {Object} options.username
- * @param {Object} options.password
- * @param {Object} options.database
- * @param {Object} options.host
- * @param {Object} options.port
+ * @param {Object} options.connectionname
  * @param {Object} options.mapping
  * @param {Object} options.includeErrors
  * @returns Transform
@@ -59,37 +55,17 @@ function writeInsertStatement(columnMapping, table, chunk){
 function PostgresDestination(options){
     EventEmitter.call(this)
     const table = options.table
-    const username = options.username
-    const password = options.password
-    const database = options.database
-    const host = options.host
-    const port = options.port || DEFAULT_PORT
+    const connectionname = options.connectionname
     const mapping = options.mapping
     const includeErrors = options.includeErrors
     let lastChunk
 
-    const sequelize = new Sequelize(database, username, password, {
-        host: host,
-        port: port,
-        dialect: 'postgres',
-        logging: false
-    })
-
-    try{
-        sequelize.authenticate()
-        debug('sequelize.authenticate succeeded')
-    } catch(e){
-        debug('sequelize.authenticate failed')
-        debug(e)
-        throw e
-    }
-    
     return new Transform({
         objectMode: true,
         emitClose: true,
         construct(callback){
-                        // @ts-ignore
-            this.sequelize = sequelize
+            // @ts-ignore
+            this.connectionname = connectionname
             callback()
         },
         write(chunk, _, callback){
@@ -120,6 +96,12 @@ function PostgresDestination(options){
         final(callback){
             this.emit('result', lastChunk)
             callback()
+        },
+        setConnection(connection){
+            this.connection = connection
+        },
+        getConnectionName(){
+            return this.getConnectionName
         }
     })
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,6 +8,7 @@ const { compose } = require("node:stream")
  * @typedef {Object} Etl
  * @function loader 
  * @function pump
+ * @function connection
  * @function validator
  * @function destination
  * @function transform
@@ -20,6 +21,7 @@ const { compose } = require("node:stream")
 function Etl(){
     EventEmitter.call(this)
     let self = this
+    self.connectionList = []
     self.validatorList = []
     self.transformationList = []
     self.destinationList = []
@@ -44,6 +46,11 @@ function Etl(){
             return self
     }
 
+    this.connection = (connection) => {
+        self.connectionList.push(connection)
+        return self
+    }
+
     this.validator = (validator) => {
         self.validatorList.push(validator)
         return self
@@ -55,6 +62,15 @@ function Etl(){
     }
 
     this.transform = (transform) => {
+        const connectionname = transform.getConnectionName
+        if (!connectionname || connectionname === ''){
+            throw new Error('Connection name must be specified')
+        }
+        const connection = this.connectionList.filter(c => c.name === connectionname)
+        if (!connection) {
+            throw new Error(`Connection with name ${connectionname} not found`)
+        }
+        transform.setConnection(connection)
         self.transformationList.push(transform)
         return self
     }

--- a/src/misc/postgresSQLTask.js
+++ b/src/misc/postgresSQLTask.js
@@ -1,0 +1,23 @@
+// @ts-nocheck
+const { PassThrough } = require("stream")
+
+function PostgresSQLTask(options){
+  return new PassThrough({
+    readableObjectMode: true,
+    writableObjectMode: true,
+    decodeStrings: false,
+    construct(callback){
+        this.sql = options.sql      
+        callback()
+    },
+    transform(chunk, _, callback){
+        console.log(chunk)
+        console.log(this.sql)
+        callback(null, chunk)
+    }
+  })
+}
+
+module.exports = {
+  PostgresSQLTask
+}

--- a/test/database_connections/postgresDatabaseConnection.test.js
+++ b/test/database_connections/postgresDatabaseConnection.test.js
@@ -1,0 +1,51 @@
+const { expect } = require('@jest/globals')
+const Connections = require('../../src/database_connections')
+const { Sequelize } = require('sequelize')
+
+jest.mock('sequelize', () => ({
+  Sequelize: jest.fn().mockImplementation(()=>({
+    authenticate: jest.fn().mockResolvedValue(true),
+    query: jest.fn().mockResolvedValue([[], 1]),
+  }))
+  })
+)
+
+describe('postgresConnection tests', () => {
+  beforeEach(() => {
+      jest.clearAllMocks()
+  })
+  it('should connect', async () => {
+    const connectionName = 'MyConnection'
+    const databaseName = 'MyTestDB'
+    const userName = 'testUser'
+    const password = 'testPassword'
+    const host = 'localhost'
+    const port = 1234
+
+    const uut  = await Connections.PostgresDatabaseConnection({
+      connectionname: connectionName,
+      database: databaseName,
+      username: userName,
+      password: password,
+      host: host,
+      port: port
+    })
+
+    expect(uut.name).toEqual(connectionName)
+    expect(uut.db).toBeTruthy()
+    expect(Sequelize).toBeCalledTimes(1)
+    expect(Sequelize).toBeCalledWith(
+        databaseName, 
+        userName, 
+        password, 
+        {
+            "dialect": "postgres", 
+            "host": host, 
+            "logging": false, 
+            "port": port
+        }
+    )
+    //Cannot get the following assertion to work
+    expect(Sequelize().authenticate).toHaveBeenCalled()
+  })
+})

--- a/test/destinations/postgresDestination.test.js
+++ b/test/destinations/postgresDestination.test.js
@@ -1,7 +1,6 @@
 const { expect } = require('@jest/globals')
 const { 
-    PostgresDestination, writeInsertStatement, isKeyWord, 
-    getMappingForColumn 
+    PostgresDestination, writeInsertStatement
 } = require('../../src/destinations/postgresDestination')
 const { Readable } = require('node:stream')
 const { Sequelize } = require('sequelize')
@@ -55,6 +54,7 @@ describe('postgresDestination tests', () => {
         jest.clearAllMocks()
     })
     it('should write a row', (done) => {
+        // This test was working fine until today
         const uut = new PostgresDestination(config)
         const testData =["a", "b", "c"]
         testData.errors = []
@@ -69,6 +69,7 @@ describe('postgresDestination tests', () => {
             .pipe(uut)
     })
     it('should fire result event', (done) => {
+        // This test was working fine until today
         const uut = new PostgresDestination(config)
         const testData =["a", "b", "c"]
         testData.errors = []
@@ -88,6 +89,7 @@ describe('postgresDestination tests', () => {
             }))
     })
     it('should produce debug output', (done) => {
+        // This test was working fine until today
         const uut = new PostgresDestination(config)
         const testData =["a", "b", "c"]
         testData.errors = []
@@ -102,6 +104,7 @@ describe('postgresDestination tests', () => {
             .pipe(uut)
     })
     it('should connect to different port', () => {
+        // This test was working fine until today
         new PostgresDestination({
             username: "postgres",
             password : "abc",
@@ -142,6 +145,7 @@ describe('postgresDestination tests', () => {
         }
     )
     it('should format a date as specified', (done) => {
+        // This test was working fine until today
         const newConfig = JSON.parse(JSON.stringify(config))
         newConfig.mapping[1].targetType = "date"
         newConfig.mapping[1].format = "DD-MM-YYYY HH24:MI:SS"

--- a/test/misc/postgresSQLTask.test.js
+++ b/test/misc/postgresSQLTask.test.js
@@ -1,0 +1,11 @@
+const { PostgresSQLTask } = require('../../src/misc/postgresSQLTask.js')
+const { expect } = require("@jest/globals")
+
+describe('PostgresSQLTask tests', () => {
+  it('should execute plain sql', (done) => {
+    const uut = new PostgresSQLTask({ sql: "INSERT INTO Foo(bar,baz) VALUES (1,2);"})
+    uut
+      .on('data', () => done())
+      .write([1,2,3,4,5])
+  })
+})


### PR DESCRIPTION
WIP PR

Need a second pair of eyes on the unit testing. Unit testing Sequelize is really problematic. Sequelize itself messes with its own prototypical inheritance chain, [for example](https://github.com/sequelize/sequelize/blob/705ab0d81c1d43e2add72b1b1ebd4bb4e7a54c6b/packages/core/src/sequelize.js#L788)

The authenticate method is an asynchronous method defined [here](https://github.com/sequelize/sequelize/blob/705ab0d81c1d43e2add72b1b1ebd4bb4e7a54c6b/packages/core/src/sequelize.js#L588) and looks like it is defined as part of the main class which is defined [here](https://github.com/sequelize/sequelize/blob/705ab0d81c1d43e2add72b1b1ebd4bb4e7a54c6b/packages/core/src/sequelize.js#L70)

I can mock Sequelize, and it looks like the mocks are getting used in the uut but I cannot reference the mocks to make assertions.

What I have used in the past that was working right up until today, in the case of PostgresDestination unit tests was this mock

```js
jest.mock('sequelize', () => ({
  Sequelize: jest.fn().mockImplementation(()=>({
    authenticate: jest.fn().mockResolvedValue(true),
    query: jest.fn().mockResolvedValue([[], 1]),
  }))
  })
)
```

Except that now in my unit test when I try and make the following assertion

```js
expect(Sequelize().authenticate).toHaveBeenCalled()
```
I get a call count of 0?

The first 5 unit tests of 'postgresDestination tests' which were working have stopped working today and have not been altered.