### PR TITLE
added schema and relax quotes support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-pay-etl-framework",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-pay-etl-framework",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@faker-js/faker": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-etl-framework",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "publisher": "Defra",
   "main": "dist/cjs/index.js",
   "private": false,

--- a/test/destinations/postgresDestination.test.js
+++ b/test/destinations/postgresDestination.test.js
@@ -58,7 +58,7 @@ describe('postgresDestination tests', () => {
         const readable = Readable.from([testData])
         readable
             .on('close', (result) => {
-                expect(mockConnection.db.query).toHaveBeenLastCalledWith(`INSERT INTO "target" ("target_column1","target_column2","target_column3") VALUES ('a','b','c')`)
+                expect(mockConnection.db.query).toHaveBeenLastCalledWith(`INSERT INTO public."target" ("target_column1","target_column2","target_column3") VALUES ('a','b','c')`)
                 done()
             })
             .pipe(uut)
@@ -133,7 +133,7 @@ describe('postgresDestination tests', () => {
         const readable = Readable.from([testData])
         readable
             .on('close', (result) => {
-                expect(mockConnection.db.query).toHaveBeenLastCalledWith(`INSERT INTO "target" ("target_column1","target_column2","target_column3") VALUES ('a',to_timestamp('19-06-2024 00:00','DD-MM-YYYY HH24:MI:SS'),'c')`)
+                expect(mockConnection.db.query).toHaveBeenLastCalledWith(`INSERT INTO public."target" ("target_column1","target_column2","target_column3") VALUES ('a',to_timestamp('19-06-2024 00:00','DD-MM-YYYY HH24:MI:SS'),'c')`)
                 done()
             })
             .pipe(uut)
@@ -145,7 +145,17 @@ describe('postgresDestination tests', () => {
         mockChunk.rowId = 1
         mockChunk._columns = ["column1", "column2", "column3"]
         const result = writeInsertStatement(config.mapping, mockTable, mockChunk)
-        expect(result).toEqual(`INSERT INTO "MockTable" ("target_column1","target_column2","target_column3") VALUES ('a','19-06-2024 00:00','c')`)
+        expect(result).toEqual(`INSERT INTO public."MockTable" ("target_column1","target_column2","target_column3") VALUES ('a','19-06-2024 00:00','c')`)
+    })
+    it('should write a sql statement with schema if provided', () => {
+        const mockTable = "MockTable"
+        const mockChunk = ["a", "19-06-2024 00:00", "c"]
+        const mockSchema = 'mydatabase123'
+        mockChunk.errors = []
+        mockChunk.rowId = 1
+        mockChunk._columns = ["column1", "column2", "column3"]
+        const result = writeInsertStatement(config.mapping, mockTable, mockChunk, mockSchema)
+        expect(result).toEqual(`INSERT INTO mydatabase123."MockTable" ("target_column1","target_column2","target_column3") VALUES ('a','19-06-2024 00:00','c')`)
     })
     it('should write a sql statement with a date format', () => {
         const newMapping = JSON.parse(JSON.stringify(config.mapping))
@@ -157,7 +167,7 @@ describe('postgresDestination tests', () => {
         mockChunk.rowId = 1
         mockChunk._columns = ["column1", "column2", "column3"]
         const result = writeInsertStatement(newMapping, mockTable, mockChunk)
-        expect(result).toEqual(`INSERT INTO "MockTable" ("target_column1","target_column2","target_column3") VALUES ('a',to_timestamp('19-06-2024 00:00','DD-MM-YYYY HH24:MI:SS'),'c')`)
+        expect(result).toEqual(`INSERT INTO public."MockTable" ("target_column1","target_column2","target_column3") VALUES ('a',to_timestamp('19-06-2024 00:00','DD-MM-YYYY HH24:MI:SS'),'c')`)
     })
     it('should write a sql statement correctly if date but no value', () => {
         const newMapping = JSON.parse(JSON.stringify(config.mapping))
@@ -169,7 +179,7 @@ describe('postgresDestination tests', () => {
         mockChunk.rowId = 1
         mockChunk._columns = ["column1", "column2", "column3"]
         const result = writeInsertStatement(newMapping, mockTable, mockChunk)
-        expect(result).toEqual(`INSERT INTO "MockTable" ("target_column1","target_column2","target_column3") VALUES ('a','','c')`)
+        expect(result).toEqual(`INSERT INTO public."MockTable" ("target_column1","target_column2","target_column3") VALUES ('a','','c')`)
     })
     it('should write a sql statement when a target column is a keyword', () => {
         const newMapping = JSON.parse(JSON.stringify(config.mapping))
@@ -182,7 +192,7 @@ describe('postgresDestination tests', () => {
         mockChunk.rowId = 1
         mockChunk._columns = ["column1", "column2", "column3"]
         const result = writeInsertStatement(newMapping, mockTable, mockChunk)
-        expect(result).toEqual(`INSERT INTO "MockTable" ("target_column1",\"User\","target_column3") VALUES ('a',to_timestamp('19-06-2024 00:00','DD-MM-YYYY HH24:MI:SS'),'c')`)
+        expect(result).toEqual(`INSERT INTO public."MockTable" ("target_column1",\"User\","target_column3") VALUES ('a',to_timestamp('19-06-2024 00:00','DD-MM-YYYY HH24:MI:SS'),'c')`)
     })
     it('should write a sql statement when a source column is a keyword and there is no target column', () => {
         const newMapping = JSON.parse(JSON.stringify(config.mapping))
@@ -196,7 +206,7 @@ describe('postgresDestination tests', () => {
         mockChunk.rowId = 1
         mockChunk._columns = ["column1", "User", "column3"]
         const result = writeInsertStatement(newMapping, mockTable, mockChunk)
-        expect(result).toEqual(`INSERT INTO "MockTable" ("target_column1",\"User\","target_column3") VALUES ('a',to_timestamp('19-06-2024 00:00','DD-MM-YYYY HH24:MI:SS'),'c')`)
+        expect(result).toEqual(`INSERT INTO public."MockTable" ("target_column1",\"User\","target_column3") VALUES ('a',to_timestamp('19-06-2024 00:00','DD-MM-YYYY HH24:MI:SS'),'c')`)
     })
     it('should write a sql statement when a target column type is a number', () => {
         const newMapping = JSON.parse(JSON.stringify(config.mapping))
@@ -208,7 +218,7 @@ describe('postgresDestination tests', () => {
         mockChunk.rowId = 1
         mockChunk._columns = ["column1", "column2", "column3"]
         const result = writeInsertStatement(newMapping, mockTable, mockChunk)
-        expect(result).toEqual(`INSERT INTO "MockTable" ("target_column1","target_column2","target_column3") VALUES ('a',999,'c')`)
+        expect(result).toEqual(`INSERT INTO public."MockTable" ("target_column1","target_column2","target_column3") VALUES ('a',999,'c')`)
     })
     it('should write a sql statement when a target column type is a number but the value is NaN', () => {
         const newMapping = JSON.parse(JSON.stringify(config.mapping))
@@ -220,7 +230,7 @@ describe('postgresDestination tests', () => {
         mockChunk.rowId = 1
         mockChunk._columns = ["column1", "column2", "column3"]
         const result = writeInsertStatement(newMapping, mockTable, mockChunk)
-        expect(result).toEqual(`INSERT INTO "MockTable" ("target_column1","target_column2","target_column3") VALUES ('a',0,'c')`)
+        expect(result).toEqual(`INSERT INTO public."MockTable" ("target_column1","target_column2","target_column3") VALUES ('a',0,'c')`)
     })
     it('should write a sql statement when a target column has the returning flag set', () => {
         const newMapping = JSON.parse(JSON.stringify(config.mapping))
@@ -231,7 +241,7 @@ describe('postgresDestination tests', () => {
         mockChunk.rowId = 1
         mockChunk._columns = ["column1", "column2", "column3"]
         const result = writeInsertStatement(newMapping, mockTable, mockChunk)
-        expect(result).toEqual(`INSERT INTO "MockTable" ("target_column1","target_column2","target_column3") VALUES ('a','a999','c') RETURNING target_column2`)
+        expect(result).toEqual(`INSERT INTO public."MockTable" ("target_column1","target_column2","target_column3") VALUES ('a','a999','c') RETURNING target_column2`)
     })
     it('should fire off any addtional tasks', (done) => {
         const mockTasks = [{
@@ -249,7 +259,7 @@ describe('postgresDestination tests', () => {
         const readable = Readable.from([testData])
         readable
             .on('close', (result) => {
-                expect(mockConnection.db.query).toHaveBeenLastCalledWith(`INSERT INTO "target" ("target_column1","target_column2","target_column3") VALUES ('a','b','c')`)
+                expect(mockConnection.db.query).toHaveBeenLastCalledWith(`INSERT INTO public."target" ("target_column1","target_column2","target_column3") VALUES ('a','b','c')`)
                 expect(mockTasks[0].write).toHaveBeenCalled()
                 expect(mockTasks[0].write).toBeCalledWith(testData)
                 done()


### PR DESCRIPTION
# Description

Ensures that postgres insert scripts will include the schema name to allow schemas to be passed. This is particularly helpful when testing against services that do not want to reference the public instance.

Also adds support for the 'relax_quotes' feature of csvLoader.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested use on locally built ffc-doc-statement-data
- [x] Added modified unit tests to cover this behaviour

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules